### PR TITLE
fixed layer naming

### DIFF
--- a/R/processData.R
+++ b/R/processData.R
@@ -307,7 +307,6 @@ setMethod(
     
     
     outStack <- raster::stack(anthroBuff, natDist, all)
-    names(outStack) = c("anthroBuff", "natDist", "totalDist")
 
     if(requireNamespace("fasterize", quietly = TRUE)){
       pp = fasterize::fasterize(inData@projectPoly,outStack[[1]])
@@ -318,6 +317,8 @@ setMethod(
     
     #set NAs from landcover
     outStack[is.na(landCover) | (landCover == 0)|is.na(pp)] = NA
+    
+    names(outStack) = c("anthroBuff", "natDist", "totalDist")
     
     inData@processedData <- outStack
     


### PR DESCRIPTION
Craig, I hope that I have done this correctly. Please let me know if I should have done something differently. This is my first time doing a pull request.

Pretty simple fix. I think the fasterize package was dropping the layer names after they were assigned in the previous iteration. I simply moved the naming line to after the fasterize package which produces named layers properly.