### PR TITLE
add pfocal to movingWindowAvg

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,7 +88,8 @@ Suggests:
     tmap,
     tmaptools,
     ggplot2,
-    fasterize
+    fasterize,
+    pfocal
 VignetteBuilder: knitr
 Depends: 
     R (>= 2.10)

--- a/tests/testthat/test-movingWindowAvg.R
+++ b/tests/testthat/test-movingWindowAvg.R
@@ -1,31 +1,82 @@
 context("Test movingWindowAvg")
 
-test_that("movingWindowAvg gives expected result on dummy data", {
-  mat <- matrix(c(rep(1,5000), rep(2, 5000)), nrow = 100, ncol = 100)
-  exps <- raster(mat, xmn = 0, xmx = 100, ymn = 0, ymx = 100)
-  lyrs <- layerize(exps)
-  pt <- st_sfc(st_point(c(49.5, 50))) %>% st_sf(PID = 1) %>%
-    set_names(c("PID", "geometry")) %>% st_set_geometry("geometry")
-  
-  # Internal of function helpful for interactive testing
-  # cf2 <- focalWeight(lyrs, 2.5, "circle")
-  # #cf2[which(cf2 > 0)] <- 1
-  # cf2ras <- raster(cf2, xmn = 0.2, xmx = 0.7, ymn = 0.2, ymx = 0.7)
-  # 
-  # # Need to use sum focal with weights that will give mean instead of mean
-  # # because mean counts cells with weight 0 in the denominator and so doesn't
-  # # work
-  # rast <- velox::velox(lyrs)
-  # rast$sumFocal(cf2, bands = 1:2)
-  # 
-  # out <- rast$extract_points(sp = pt)
-  # outRast <- rast$as.RasterLayer()
+mat <- matrix(c(rep(1,5000), rep(2, 5000)), nrow = 100, ncol = 100)
+exps <- raster(mat, xmn = 0, xmx = 100, ymn = 0, ymx = 100)
+lyrs <- layerize(exps)
+pt <- st_sfc(st_point(c(49.5, 50))) %>% st_sf(PID = 1) %>%
+  set_names(c("PID", "geometry")) %>% st_set_geometry("geometry")
 
-  res <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = FALSE)
+res <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = FALSE)
+
+res2 <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE)
+
+test_that("movingWindowAvg gives expected result on dummy data", {
+
   expect_equal(raster::extract(res$X1, pt), 13/21)
-  
-  res2 <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE)
   expect_gt(raster::extract(res$X1, pt), raster::extract(res2$X1, pt))
   })
 
+test_that("pfocal and raster versions give same results",{
+  res_rast <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = FALSE, 
+                              usePfocal = FALSE)
+  
+  res2_rast <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, 
+                               usePfocal = FALSE)
+  
+  expect_equal(res, res_rast)
+  
+  expect_equal(res2, res2_rast)
+  
+  # for different padding situations as well
+  res2_pad <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, pad = TRUE,
+                              padValue = NA)
+  
+  res2_pad_rast <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, pad = TRUE,
+                                   padValue = NA, usePfocal = FALSE)
+  
+  expect_equal(res2_pad, res2_pad_rast)
+  
+  res2_pad1 <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, pad = TRUE,
+                              padValue = 1)
+  
+  res2_pad1_rast <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, pad = TRUE,
+                                   padValue = 1, usePfocal = FALSE)
+  
+  expect_equal(res2_pad1, res2_pad1_rast)
+  
+  res2_pad_naF <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, pad = TRUE,
+                              padValue = NA, na.rm = FALSE)
+  
+  res2_pad_naF_rast <- movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, pad = TRUE,
+                                   padValue = NA, usePfocal = FALSE, na.rm = FALSE)
+  
+  expect_equal(res2_pad_naF, res2_pad_naF_rast)
+  
+  # for NAs not on the edge
+  lyrs2 <- lyrs
+  lyrs2[40,50] <- NA
+  
+  res3 <- movingWindowAvg(lyrs2, 2.5, c("X1", "X2"), offset = TRUE)
+  
+  res3_rast <- movingWindowAvg(lyrs2, 2.5, c("X1", "X2"), offset = TRUE,
+                                   usePfocal = FALSE)
+  
+  expect_equal(res3, res3_rast)
+})
 
+# use bench::mark to compare speed
+# bm <- bench::mark(pfocal = movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE),
+#                   rasterfocal = movingWindowAvg(lyrs, 2.5, c("X1", "X2"), offset = TRUE, 
+#                                                 usePfocal = FALSE),
+#                   iterations = 10)
+# plot(bm)
+
+# # A tibble: 2 x 13
+#   expression     min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time result
+#   <bch:expr>  <bch:> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm> <list>
+# 1 pfocal      32.8ms 33.2ms      29.9    2.33MB     3.32     9     1      301ms <Rstr~
+# 2 rasterfocal 37.7ms 38.7ms      24.1    1.41MB     2.67     9     1      374ms <Rstr~
+# # ... with 3 more variables: memory <list>, time <list>, gc <list>
+
+# difference in speed is larger for a bigger raster but the same if there is a
+# level2 gc


### PR DESCRIPTION
It is now the default to use it if it is installed and it is in suggests. Can use usePfocal argument to toggle on and off. I did not use the pfocal kernals but in the future that might be more generalizable than the current system which copies the "offsetting" used by Hornseth and Rempel.